### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/helper/DiffEmitter.ts
+++ b/src/helper/DiffEmitter.ts
@@ -26,7 +26,7 @@ function mergeDiff(olds: IDiffEvent[], change: IDiffEvent): IDiffEvent[] {
             return olds;
             // Merge and pop already existing information into a single object
         } else if (event.path.startsWith(path)) {
-            set(old, event.path.substr(path.length + 1), event.old);
+            set(old, event.path.slice(path.length + 1), event.old);
             olds.splice(i, i + 1);
         } else {
             i++;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.